### PR TITLE
Support variables exported via :export

### DIFF
--- a/.changeset/stupid-boxes-scream.md
+++ b/.changeset/stupid-boxes-scream.md
@@ -1,0 +1,5 @@
+---
+"postcss-typesafe-css-modules": minor
+---
+
+Support variables and values exported via `:export`

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ src/
   hello.tsx                   # Contains the import for header.module.scss
 build/
   postcss/
-    _hello.module.css         # Compiled CSS that is imported by hello.module.scss.js
+    _hello.css                # Compiled CSS that is imported by hello.module.scss.js
     hello.module.scss.js      # File actually imported by hello.tsx
     hello.module.scss.js.map
     hello.module.scss.d.ts

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ For example, if you have the following SCSS module file:
 
 ```css
 // header.module.scss
+$page-width: 850px;
+
+:export {
+    pageWidth: $page-width;
+}
+
 .header {
     font-size: 1.5rem;
 }
@@ -22,6 +28,7 @@ import React from "react";
 import * as css from "./header.module.scss";
 
 export const Header: React.FC = () => {
+    const width = css.pageWidth; // "850px"
     return <header className={css.header}>Hello</header>;
 };
 ```
@@ -36,6 +43,22 @@ export const Header: React.FC = () => {
     // Will fail to compile
     return <header className={css.nonExistent}>Hello</header>;
 };
+```
+
+Note that if there is a naming conflict between an exported variable (via `:export`) and a class name, this plugin will throw to prevent surprising behavior:
+
+```css
+// header.module.scss
+$header-width: 850px;
+
+:export {
+    // Will cause an error
+    header: $header-width;
+}
+
+.header {
+    font-size: 1.5rem;
+}
 ```
 
 ## Usage
@@ -58,10 +81,7 @@ import cssModulesPlugin from "postcss-typesafe-css-modules";
 
 export default {
     syntax: scss,
-    plugins: [
-        scssPlugin(),
-        cssModulesPlugin,
-    ],
+    plugins: [scssPlugin(), cssModulesPlugin],
 };
 ```
 

--- a/src/Stylesheet.ts
+++ b/src/Stylesheet.ts
@@ -5,11 +5,12 @@
 import { LinesAndColumns, type SourceLocation } from "lines-and-columns";
 
 export class Stylesheet {
-    private index: Map<string, SourceLocation | undefined>;
+    private classIndex: Map<string, SourceLocation | undefined>;
+    private variablesIndex: Map<string, SourceLocation | undefined>;
 
     public constructor(source: string) {
         const stylesheet = new LinesAndColumns(source);
-        this.index = new Map(
+        this.classIndex = new Map(
             [...source.matchAll(/\.(?<className>[\w-]+)\s+{/g)]
                 .filter(match => match.index != null)
                 .map(match => {
@@ -21,11 +22,43 @@ export class Stylesheet {
                     return [match.groups?.className!, location] as const;
                 }),
         );
+
+        // To make sure we don't catch Sass variable declartions, we only look between :export {}
+        const variableExports = source.match(/:export\s*{\s*([^}]+)}/);
+        if (variableExports == null || variableExports.length < 2) {
+            this.variablesIndex = new Map();
+        } else {
+            // We're looking in within the string extracted from between `:export {}`, so we calculate
+            // the offset in the original file to calculate the correct line and column numbers later
+            const offset =
+                variableExports.index! +
+                variableExports[0].indexOf(variableExports[1]);
+            this.variablesIndex = new Map(
+                [...variableExports[1].matchAll(/(?<variableName>[\w-]+)\s*:/g)]
+                    .filter(match => match.index != null)
+                    .map(match => {
+                        const location =
+                            stylesheet.locationForIndex(
+                                match.index! + offset,
+                            ) ?? undefined;
+                        if (location != null) {
+                            location.line = location.line + 1;
+                        }
+                        return [match.groups?.variableName!, location] as const;
+                    }),
+            );
+        }
     }
 
     public findClass(
         className: string,
     ): { line: number; column: number } | undefined {
-        return this.index.get(className);
+        return this.classIndex.get(className);
+    }
+
+    public findVariable(
+        variableName: string,
+    ): { line: number; column: number } | undefined {
+        return this.variablesIndex.get(variableName);
     }
 }

--- a/src/Stylesheet.ts
+++ b/src/Stylesheet.ts
@@ -28,13 +28,12 @@ export class Stylesheet {
         if (variableExports == null || variableExports.length < 2) {
             this.variablesIndex = new Map();
         } else {
-            // We're looking in within the string extracted from between `:export {}`, so we calculate
-            // the offset in the original file to calculate the correct line and column numbers later
+            const [variableExportsMatch, exportedVariables] = variableExports;
             const offset =
                 variableExports.index! +
-                variableExports[0].indexOf(variableExports[1]);
+                variableExportsMatch.indexOf(exportedVariables);
             this.variablesIndex = new Map(
-                [...variableExports[1].matchAll(/(?<variableName>[\w-]+)\s*:/g)]
+                [...exportedVariables.matchAll(/(?<variableName>[\w-]+)\s*:/g)]
                     .filter(match => match.index != null)
                     .map(match => {
                         const location =

--- a/src/typeSafeCssModulesPlugin.ts
+++ b/src/typeSafeCssModulesPlugin.ts
@@ -27,7 +27,7 @@ export const typeSafeCssModulesPlugin: PluginCreator<
             // Index the stylesheet so that we can lookup lines & columns
             const stylesheet = new Stylesheet(await fs.readFile(from, "utf8"));
 
-            const variables = [...Object.entries(exportTokens)].map(
+            const cssModuleExports = [...Object.entries(exportTokens)].map(
                 ([tokenName, tokenValue]) => {
                     // postcss-modules automatically picks the last declared name to use in exportTokens
                     // In a scenario where an exported variable and a class name shares the same name,
@@ -53,7 +53,7 @@ export const typeSafeCssModulesPlugin: PluginCreator<
             // Generate the JavaScript file
             const js = new SourceNode(null, null, sourceFile, [
                 `import "./${path.basename(to)}";\n\n`,
-                ...variables.flatMap(el => [
+                ...cssModuleExports.flatMap(el => [
                     new SourceNode(null, null, sourceFile, `export const `),
                     new SourceNode(
                         el.location?.line ?? null,
@@ -62,14 +62,14 @@ export const typeSafeCssModulesPlugin: PluginCreator<
                         `${el.variableName} = "${el.value}";\n`,
                     ),
                 ]),
-                `export default { ${variables
+                `export default { ${cssModuleExports
                     .map(el => el.variableName)
                     .join(", ")} };\n`,
             ]).toStringWithSourceMap();
 
             // Generate the TypeScript .d.ts file
             const dts = new SourceNode(null, null, sourceFile, [
-                ...variables.flatMap(el => {
+                ...cssModuleExports.flatMap(el => {
                     return [
                         new SourceNode(
                             null,
@@ -88,7 +88,7 @@ export const typeSafeCssModulesPlugin: PluginCreator<
                 "\n",
                 `declare const `,
                 new SourceNode(1, 0, sourceFile, `__defaultExports: {\n`),
-                ...variables.flatMap(el => [
+                ...cssModuleExports.flatMap(el => [
                     ` `,
                     new SourceNode(
                         el.location?.line ?? null,


### PR DESCRIPTION
Closes https://github.com/styu/postcss-typesafe-css-modules/issues/23

This implements option 3 (which funnily enough, this plugin was already doing since the generated JSON already doesn't distinguish between `:export` or CSS class names). The main changes I added were:
- Fix the source maps to point to the correct line in the `:export` block, since the regex for class names didn't apply
- Catch the scenario where the exported variable is both in `:export` and a class name, and throw. I don't think it's otherwise obvious that the last one wins (and thus the `:export` variable that has the same name is just silently ignored)