### PR TITLE
Fix instructions in README

### DIFF
--- a/.changeset/small-rockets-love.md
+++ b/.changeset/small-rockets-love.md
@@ -1,0 +1,5 @@
+---
+"postcss-typesafe-css-modules": patch
+---
+
+Fix instructions in README

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ module.exports = {
     syntax: require("postcss-scss"),
     plugins: [
         require("@csstools/postcss-sass")(),
-        require("postcss-typesafe-css-modules").default,
+        require("postcss-typesafe-css-modules"),
     ],
 };
 ```
@@ -120,7 +120,7 @@ Currently this plugin has one option, forwarded to postcss-modules. See [Generat
 
 ```js
 import cssModulesPlugin from "postcss-typesafe-css-modules";
-cssModulesPlugin.default({
+cssModulesPlugin({
     generateScopedName: /* Your desired scoped name behavior */
 })
 ```


### PR DESCRIPTION
https://github.com/styu/postcss-typesafe-css-modules/pull/36 made it so you don't need to access `.default` anymore